### PR TITLE
[webhooks] add client methods

### DIFF
--- a/smsgateway/domain_webhooks.go
+++ b/smsgateway/domain_webhooks.go
@@ -23,6 +23,17 @@ var allEventTypes = map[WebhookEvent]struct{}{
 	WebhookEventSystemPing:   {},
 }
 
+// WebhookEventTypes returns a slice of all supported webhook event types.
+func WebhookEventTypes() []WebhookEvent {
+	return []WebhookEvent{
+		WebhookEventSmsReceived,
+		WebhookEventSmsSent,
+		WebhookEventSmsDelivered,
+		WebhookEventSmsFailed,
+		WebhookEventSystemPing,
+	}
+}
+
 // IsValid checks if the given event type is valid.
 //
 // e is the event type to be checked.
@@ -35,7 +46,7 @@ func IsValidWebhookEvent(e WebhookEvent) bool {
 // A webhook configuration.
 type Webhook struct {
 	// The unique identifier of the webhook.
-	ID string `json:"id" validate:"max=36" example:"123e4567-e89b-12d3-a456-426614174000"`
+	ID string `json:"id,omitempty" validate:"max=36" example:"123e4567-e89b-12d3-a456-426614174000"`
 
 	// The URL the webhook will be sent to.
 	URL string `json:"url" validate:"required,http_url" example:"https://example.com/webhook"`

--- a/smsgateway/domain_webhooks_test.go
+++ b/smsgateway/domain_webhooks_test.go
@@ -32,3 +32,13 @@ func TestIsValidEventType(t *testing.T) {
 		})
 	}
 }
+
+// TestWebhookEventTypes tests that the event types returned by
+// WebhookEventTypes are all valid.
+func TestWebhookEventTypes(t *testing.T) {
+	for _, v := range smsgateway.WebhookEventTypes() {
+		if !smsgateway.IsValidWebhookEvent(v) {
+			t.Errorf("event type %s is not valid", v)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added webhook management capabilities to the SMS gateway client.
	- Users can now list, register, and delete webhooks through the API client.
	- Introduced a function to retrieve all supported webhook event types.
- **Bug Fixes**
	- Updated JSON serialization for the `ID` field in the `Webhook` struct to omit empty values.
- **Tests**
	- Introduced new unit tests for webhook management functionalities and event type validation, ensuring proper response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->