### PR TITLE
[responses] omit empty username and password for existing account on …

### DIFF
--- a/smsgateway/responses.go
+++ b/smsgateway/responses.go
@@ -8,10 +8,10 @@ type MobileDeviceResponse struct {
 
 // Device registration response
 type MobileRegisterResponse struct {
-	Id       string `json:"id" example:"QslD_GefqiYV6RQXdkM6V"`    // New device ID
-	Token    string `json:"token" example:"bP0ZdK6rC6hCYZSjzmqhQ"` // Device access token
-	Login    string `json:"login" example:"VQ4GII"`                // User login
-	Password string `json:"password" example:"cp2pydvxd2zwpx"`     // User password
+	Id       string `json:"id" example:"QslD_GefqiYV6RQXdkM6V"`          // New device ID
+	Token    string `json:"token" example:"bP0ZdK6rC6hCYZSjzmqhQ"`       // Device access token
+	Login    string `json:"login,omitempty" example:"VQ4GII"`            // User login, empty if registration in existing user
+	Password string `json:"password,omitempty" example:"cp2pydvxd2zwpx"` // User password, empty if registration in existing user
 }
 
 // Error response


### PR DESCRIPTION
…device registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Mobile registration responses now only include login and password information when they contain values, resulting in cleaner outputs, particularly for existing users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->