### PR TITLE
[bugfix] make login required in registration response

### DIFF
--- a/smsgateway/responses.go
+++ b/smsgateway/responses.go
@@ -10,8 +10,8 @@ type MobileDeviceResponse struct {
 type MobileRegisterResponse struct {
 	Id       string `json:"id" example:"QslD_GefqiYV6RQXdkM6V"`          // New device ID
 	Token    string `json:"token" example:"bP0ZdK6rC6hCYZSjzmqhQ"`       // Device access token
-	Login    string `json:"login,omitempty" example:"VQ4GII"`            // User login, empty if registration in existing user
-	Password string `json:"password,omitempty" example:"cp2pydvxd2zwpx"` // User password, empty if registration in existing user
+	Login    string `json:"login" example:"VQ4GII"`                      // User login
+	Password string `json:"password,omitempty" example:"cp2pydvxd2zwpx"` // User password, empty for existing user
 }
 
 // Error response


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Device registration now requires providing a login credential, enhancing the onboarding process while keeping the password optional for existing users.
- **Documentation**
	- Updated field descriptions in the registration flow improve clarity on required and optional credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->