### PR TITLE
[webhooks] require https url

### DIFF
--- a/smsgateway/domain_webhooks.go
+++ b/smsgateway/domain_webhooks.go
@@ -1,5 +1,10 @@
 package smsgateway
 
+import (
+	"errors"
+	"strings"
+)
+
 type WebhookEvent = string
 
 const (
@@ -53,4 +58,18 @@ type Webhook struct {
 
 	// The type of event the webhook is triggered for.
 	Event WebhookEvent `json:"event" validate:"required" example:"sms:received"`
+}
+
+// Validate checks if the webhook is configured correctly.
+// Returns nil if validation passes, or an appropriate error otherwise.
+func (w Webhook) Validate() error {
+	if !IsValidWebhookEvent(w.Event) {
+		return errors.New("invalid event type")
+	}
+
+	if !strings.HasPrefix(strings.ToLower(w.URL), "https://") {
+		return errors.New("url must start with https://")
+	}
+
+	return nil
 }

--- a/smsgateway/domain_webhooks_test.go
+++ b/smsgateway/domain_webhooks_test.go
@@ -42,3 +42,135 @@ func TestWebhookEventTypes(t *testing.T) {
 		}
 	}
 }
+
+// TestWebhook_Validate tests the Validate method of the Webhook struct.
+func TestWebhook_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		webhook smsgateway.Webhook
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "Valid webhook with HTTPS URL",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "https://example.com/webhook",
+				Event: smsgateway.WebhookEventSmsReceived,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid event type",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "https://example.com/webhook",
+				Event: "invalid:event",
+			},
+			wantErr: true,
+			errMsg:  "invalid event type",
+		},
+		{
+			name: "Non-HTTPS URL",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "http://example.com/webhook",
+				Event: smsgateway.WebhookEventSmsReceived,
+			},
+			wantErr: true,
+			errMsg:  "url must start with https://",
+		},
+		{
+			name: "Empty URL",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "",
+				Event: smsgateway.WebhookEventSmsReceived,
+			},
+			wantErr: true,
+			errMsg:  "url must start with https://",
+		},
+		{
+			name: "Valid webhook with sms:sent event",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "https://example.com/webhook",
+				Event: smsgateway.WebhookEventSmsSent,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid webhook with sms:delivered event",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "https://example.com/webhook",
+				Event: smsgateway.WebhookEventSmsDelivered,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid webhook with sms:failed event",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "https://example.com/webhook",
+				Event: smsgateway.WebhookEventSmsFailed,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid webhook with system:ping event",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "https://example.com/webhook",
+				Event: smsgateway.WebhookEventSystemPing,
+			},
+			wantErr: false,
+		},
+		{
+			name: "URL with uppercase HTTPS",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "HTTPS://example.com/webhook",
+				Event: smsgateway.WebhookEventSmsReceived,
+			},
+			wantErr: false,
+		},
+		{
+			name: "FTP URL",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "ftp://example.com/webhook",
+				Event: smsgateway.WebhookEventSmsReceived,
+			},
+			wantErr: true,
+			errMsg:  "url must start with https://",
+		},
+		{
+			name: "Malformed URL",
+			webhook: smsgateway.Webhook{
+				ID:    "test-id",
+				URL:   "https:/example.com",
+				Event: smsgateway.WebhookEventSmsReceived,
+			},
+			wantErr: true,
+			errMsg:  "url must start with https://",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.webhook.Validate()
+
+			// Check if an error was expected
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// If we expected an error, check the error message
+			if tt.wantErr && err.Error() != tt.errMsg {
+				t.Errorf("Validate() error message = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a validation method for webhooks that checks for valid event types and ensures URLs start with "https://", providing clear error messages for invalid configurations.
- **Tests**
	- Added a comprehensive test suite for the webhook validation method, covering multiple scenarios to ensure the reliability of the validation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->