### PR TITLE
[mobile] add response for user one-time code

### DIFF
--- a/smsgateway/responses.go
+++ b/smsgateway/responses.go
@@ -1,19 +1,5 @@
 package smsgateway
 
-// Device self-information response
-type MobileDeviceResponse struct {
-	Device     *Device `json:"device,omitempty"`     // Device information, empty if device is not registered on the server
-	ExternalIP string  `json:"externalIp,omitempty"` // External IP
-}
-
-// Device registration response
-type MobileRegisterResponse struct {
-	Id       string `json:"id" example:"QslD_GefqiYV6RQXdkM6V"`          // New device ID
-	Token    string `json:"token" example:"bP0ZdK6rC6hCYZSjzmqhQ"`       // Device access token
-	Login    string `json:"login" example:"VQ4GII"`                      // User login
-	Password string `json:"password,omitempty" example:"cp2pydvxd2zwpx"` // User password, empty for existing user
-}
-
 // Error response
 type ErrorResponse struct {
 	Message string `json:"message" example:"An error occurred"` // Error message

--- a/smsgateway/responses_mobile.go
+++ b/smsgateway/responses_mobile.go
@@ -1,0 +1,23 @@
+package smsgateway
+
+import "time"
+
+// Device self-information response
+type MobileDeviceResponse struct {
+	Device     *Device `json:"device,omitempty"`     // Device information, empty if device is not registered on the server
+	ExternalIP string  `json:"externalIp,omitempty"` // External IP
+}
+
+// Device registration response
+type MobileRegisterResponse struct {
+	Id       string `json:"id" example:"QslD_GefqiYV6RQXdkM6V"`          // New device ID
+	Token    string `json:"token" example:"bP0ZdK6rC6hCYZSjzmqhQ"`       // Device access token
+	Login    string `json:"login" example:"VQ4GII"`                      // User login
+	Password string `json:"password,omitempty" example:"cp2pydvxd2zwpx"` // User password, empty for existing user
+}
+
+// User one-time code response
+type MobileUserCodeResponse struct {
+	Code       string    `json:"code" example:"123456"`                     // One-time code
+	ValidUntil time.Time `json:"validUntil" example:"2020-01-01T00:00:00Z"` // One-time code expiration time
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced mobile interactions with streamlined responses for device details and registration.
	- Introduced a new secure response that delivers a one-time code along with its validity period for improved user authentication.
- **Bug Fixes**
	- Removed obsolete response types to improve code clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->