### PR TITLE
[webhooks] add device id field

### DIFF
--- a/smsgateway/client_test.go
+++ b/smsgateway/client_test.go
@@ -182,7 +182,7 @@ func TestClient_ListWebhooks(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`[{"id":"123","url":"https://example.com","event":"sms:delivered"}]`))
+		_, _ = w.Write([]byte(`[{"id":"123","deviceId":null,"url":"https://example.com","event":"sms:delivered"}]`))
 	}))
 	defer server.Close()
 
@@ -244,13 +244,15 @@ func TestClient_RegisterWebhook(t *testing.T) {
 		body, _ := io.ReadAll(r.Body)
 		defer r.Body.Close()
 
-		if string(body) != `{"url":"https://example.com","event":"sms:delivered"}` {
+		expectedBody := `{"deviceId":null,"url":"https://example.com","event":"sms:delivered"}`
+		if string(body) != expectedBody {
 			w.WriteHeader(http.StatusBadRequest)
+			t.Errorf("Expected body %s, got %s", expectedBody, string(body))
 			return
 		}
 
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"id":"123","url":"https://example.com","event":"sms:delivered"}`))
+		_, _ = w.Write([]byte(`{"id":"123","deviceId":null,"url":"https://example.com","event":"sms:delivered"}`))
 	}))
 	defer server.Close()
 

--- a/smsgateway/domain_webhooks.go
+++ b/smsgateway/domain_webhooks.go
@@ -54,6 +54,9 @@ type Webhook struct {
 	// The unique identifier of the webhook.
 	ID string `json:"id,omitempty" validate:"max=36" example:"123e4567-e89b-12d3-a456-426614174000"`
 
+	// The unique identifier of the device the webhook is associated with.
+	DeviceID *string `json:"deviceId" validate:"omitempty,max=21" example:"PyDmBQZZXYmyxMwED8Fzy"`
+
 	// The URL the webhook will be sent to.
 	URL string `json:"url" validate:"required,http_url" example:"https://example.com/webhook"`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for an optional device ID field when configuring webhooks. This allows users to associate a unique device identifier with each webhook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->