### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/android-sms-gateway/client-go/security/code-scanning/1](https://github.com/android-sms-gateway/client-go/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out code, setting up Go, running linting, and testing, it only requires `contents: read` permissions. We will add this at the root level of the workflow to apply it to all jobs (`golangci` and `test`). This ensures that the `GITHUB_TOKEN` has minimal access across the entire workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow permissions to explicitly grant read access to repository contents. No changes to workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->