### PR TITLE
[client] add separate request and response for message state

### DIFF
--- a/smsgateway/domain_messages.go
+++ b/smsgateway/domain_messages.go
@@ -138,7 +138,7 @@ func (m *Message) Validate() error {
 // Message state
 type MessageState struct {
 	// Message ID
-	ID string `json:"id,omitempty" validate:"omitempty,max=36" example:"PyDmBQZZXYmyxMwED8Fzy"`
+	ID string `json:"id" validate:"required,max=36" example:"PyDmBQZZXYmyxMwED8Fzy"`
 	// Device ID
 	DeviceID string `json:"deviceId" validate:"required,max=21" example:"PyDmBQZZXYmyxMwED8Fzy"`
 	// State

--- a/smsgateway/requests_mobile.go
+++ b/smsgateway/requests_mobile.go
@@ -1,5 +1,7 @@
 package smsgateway
 
+import "time"
+
 // Device registration request
 type MobileRegisterRequest struct {
 	Name      *string `json:"name,omitempty" validate:"omitempty,max=128" example:"Android Phone"`    // Device name
@@ -21,3 +23,18 @@ type MobileChangePasswordRequest struct {
 	// New password, at least 14 characters
 	NewPassword string `json:"newPassword" validate:"required,min=14" example:"cp2pydvxd2zwpx"`
 }
+
+// MobilePatchMessageItem represents a single message patch request
+type MobilePatchMessageItem struct {
+	// Message ID
+	ID string `json:"id" validate:"required,max=36" example:"PyDmBQZZXYmyxMwED8Fzy"`
+	// State
+	State ProcessingState `json:"state" validate:"required" example:"Pending"`
+	// Recipients states
+	Recipients []RecipientState `json:"recipients" validate:"required,min=1,dive"`
+	// History of states
+	States map[string]time.Time `json:"states"`
+}
+
+// Message patch request
+type MobilePatchMessageRequest []MobilePatchMessageItem

--- a/smsgateway/responses_3rdparty.go
+++ b/smsgateway/responses_3rdparty.go
@@ -1,0 +1,3 @@
+package smsgateway
+
+type GetMessageResponse = MessageState


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for batch message patch requests with detailed state tracking and recipient information.
  * Introduced a new response type for retrieving message state information.
* **Bug Fixes**
  * Enforced mandatory message ID field to ensure consistent message identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->