### PR TITLE
[client] add `mms:received` event

### DIFF
--- a/smsgateway/domain_webhooks.go
+++ b/smsgateway/domain_webhooks.go
@@ -20,6 +20,8 @@ const (
 	WebhookEventSmsFailed WebhookEvent = "sms:failed"
 	// Triggered when the device pings the server.
 	WebhookEventSystemPing WebhookEvent = "system:ping"
+	// Triggered when an MMS is received.
+	WebhookEventMmsReceived WebhookEvent = "mms:received"
 )
 
 //nolint:gochecknoglobals // lookup table
@@ -30,6 +32,7 @@ var allEventTypes = map[WebhookEvent]struct{}{
 	WebhookEventSmsDelivered:    {},
 	WebhookEventSmsFailed:       {},
 	WebhookEventSystemPing:      {},
+	WebhookEventMmsReceived:     {},
 }
 
 // WebhookEventTypes returns a slice of all supported webhook event types.
@@ -41,6 +44,7 @@ func WebhookEventTypes() []WebhookEvent {
 		WebhookEventSmsDelivered,
 		WebhookEventSmsFailed,
 		WebhookEventSystemPing,
+		WebhookEventMmsReceived,
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new webhook event for incoming MMS messages. You can now subscribe to receive notifications when an MMS is received.
  * The event appears alongside existing event types in listings and selectors.
  * Existing integrations continue to work unchanged; opt in to this event to start receiving MMS notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->