### PR TITLE
[client] add refresh token method

### DIFF
--- a/smsgateway/client.go
+++ b/smsgateway/client.go
@@ -220,6 +220,22 @@ func (c *Client) GenerateToken(ctx context.Context, req TokenRequest) (TokenResp
 	return *resp, nil
 }
 
+// RefreshToken exchanges a refresh token for a new token pair.
+// Returns the refreshed token details or an error if the request fails.
+func (c *Client) RefreshToken(ctx context.Context, refreshToken string) (TokenResponse, error) {
+	path := "/auth/refresh"
+	resp := new(TokenResponse)
+	headers := map[string]string{
+		"Authorization": "Bearer " + refreshToken,
+	}
+
+	if err := c.Do(ctx, http.MethodPost, path, headers, nil, resp); err != nil {
+		return *resp, fmt.Errorf("failed to refresh token: %w", err)
+	}
+
+	return *resp, nil
+}
+
 // RevokeToken revokes an access token with the specified jti (token ID).
 // Returns an error if the revocation fails.
 func (c *Client) RevokeToken(ctx context.Context, jti string) error {

--- a/smsgateway/client_test.go
+++ b/smsgateway/client_test.go
@@ -948,6 +948,63 @@ func TestClient_GenerateToken(t *testing.T) {
 	}
 }
 
+func TestClient_RefreshToken(t *testing.T) {
+	tests := []struct {
+		name         string
+		refreshToken string
+		code         int
+		body         string
+		want         smsgateway.TokenResponse
+		wantErr      bool
+	}{
+		{
+			name:         "Success",
+			refreshToken: "refresh_token_example",
+			code:         http.StatusOK,
+			body:         `{"id":"token_id_example","token_type":"Bearer","access_token":"access_token_example","refresh_token":"refresh_token_example_new","expires_at":"2025-01-01T00:00:00Z"}`,
+			want: smsgateway.TokenResponse{
+				ID:           "token_id_example",
+				TokenType:    "Bearer",
+				AccessToken:  "access_token_example",
+				RefreshToken: "refresh_token_example_new",
+				ExpiresAt:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			wantErr: false,
+		},
+		{
+			name:         "Error response",
+			refreshToken: "refresh_token_example",
+			code:         http.StatusInternalServerError,
+			body:         `{"error": "internal error"}`,
+			want:         smsgateway.TokenResponse{},
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newMockServer(mockServerExpectedInput{
+				method:        http.MethodPost,
+				path:          "/auth/refresh",
+				authorization: "Bearer " + tt.refreshToken,
+			}, mockServerOutput{
+				code: tt.code,
+				body: tt.body,
+			})
+			defer server.Close()
+
+			client := newClient(server.URL)
+			resp, err := client.RefreshToken(context.Background(), tt.refreshToken)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RefreshToken error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(resp, tt.want) {
+				t.Errorf("RefreshToken response = %v, want %v", resp, tt.want)
+			}
+		})
+	}
+}
+
 func TestClient_RevokeToken(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### Motivation
- Provide a client-side helper to exchange a refresh token for a fresh token pair so callers can renew credentials without re-authenticating.

### Description
- Add `RefreshToken(ctx context.Context, refreshToken string) (TokenResponse, error)` to `Client`, which POSTs to `/auth/refresh` with an `Authorization: Bearer <refreshToken>` header and decodes the response into `TokenResponse`, returning a wrapped error on failure.

### Testing
- Ran `go test ./...` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a654b59b28832cb56bf271004d15c0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token refresh capability so users can exchange a refresh token for a new access/refresh token pair without re-authenticating.
* **Tests**
  * Added tests covering successful refresh and server error scenarios to ensure correct responses and robust error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->