### PR TITLE
[api] add SIM cards info fields

### DIFF
--- a/smsgateway/domain_devices.go
+++ b/smsgateway/domain_devices.go
@@ -3,24 +3,23 @@ package smsgateway
 import "time"
 
 // Device represents a device registered on the server.
-//
-// ID is the device ID, read only.
-//
-// Name is the device name.
-//
-// CreatedAt is the time at which the device was created, read only.
-//
-// UpdatedAt is the time at which the device was last updated, read only.
-//
-// DeletedAt is the time at which the device was deleted, read only.
-//
-// LastSeen is the time at which the device was last seen, read only.
 type Device struct {
-	ID        string     `json:"id"                  example:"PyDmBQZZXYmyxMwED8Fzy"` // ID
-	Name      string     `json:"name"                example:"My Device"`             // Name
-	CreatedAt time.Time  `json:"createdAt"           example:"2020-01-01T00:00:00Z"`  // Created at (read only)
-	UpdatedAt time.Time  `json:"updatedAt"           example:"2020-01-01T00:00:00Z"`  // Updated at (read only)
-	DeletedAt *time.Time `json:"deletedAt,omitempty" example:"2020-01-01T00:00:00Z"`  // Deleted at (read only)
+	ID        string     `json:"id"                  example:"PyDmBQZZXYmyxMwED8Fzy"` // Device ID, read only.
+	Name      string     `json:"name"                example:"My Device"`             // Device name.
+	CreatedAt time.Time  `json:"createdAt"           example:"2020-01-01T00:00:00Z"`  // Time at which the device was created, read only.
+	UpdatedAt time.Time  `json:"updatedAt"           example:"2020-01-01T00:00:00Z"`  // Time at which the device was last updated, read only.
+	DeletedAt *time.Time `json:"deletedAt,omitempty" example:"2020-01-01T00:00:00Z"`  // Time at which the device was deleted, read only.
 
-	LastSeen time.Time `json:"lastSeen" example:"2020-01-01T00:00:00Z"` // Last seen at (read only)
+	LastSeen time.Time `json:"lastSeen" example:"2020-01-01T00:00:00Z"` // Time at which the device was last seen, read only.
+
+	SimCards []SimCard `json:"simCards,omitempty"` // List of SIM cards in the device.
+}
+
+// SimCard represents a SIM card in an Android device.
+type SimCard struct {
+	SlotIndex   int     `json:"slotIndex"`             // 0-based physical slot index.
+	SimNumber   int     `json:"simNumber"`             // 1-based slot number (1, 2, or 3).
+	PhoneNumber *string `json:"phoneNumber,omitempty"` // Phone number associated with the SIM.
+	CarrierName *string `json:"carrierName,omitempty"` // Carrier/network operator name (may be null).
+	ICCID       *string `json:"iccid,omitempty"`       // Integrated Circuit Card Identifier (may be null).
 }

--- a/smsgateway/requests_mobile.go
+++ b/smsgateway/requests_mobile.go
@@ -3,27 +3,18 @@ package smsgateway
 import "time"
 
 // MobileRegisterRequest represents a request to register a mobile device.
-//
-// The Name field contains the name of the device, and the PushToken field
-// contains the FCM token of the device.
 type MobileRegisterRequest struct {
-	// Name of the device (optional)
-	// +optional
-	Name *string `json:"name,omitempty" validate:"omitempty,max=128" example:"Android Phone"`
-	// FCM token of the device (optional)
-	// +optional
-	PushToken *string `json:"pushToken" validate:"omitempty,max=256" example:"gHz-T6NezDlOfllr7F-Be"`
+	Name      *string   `json:"name,omitempty"     validate:"omitempty,max=128" example:"Android Phone"`         // Name of the device (optional)
+	PushToken *string   `json:"pushToken"          validate:"omitempty,max=256" example:"gHz-T6NezDlOfllr7F-Be"` // FCM token of the device (optional)
+	SimCards  []SimCard `json:"simCards,omitempty"`                                                              // SIM cards (optional)
 }
 
 // MobileUpdateRequest represents a request to update a mobile device.
-//
-// The Id field contains the device ID.
-//
-// The PushToken field contains the FCM token of the device.
 type MobileUpdateRequest struct {
 	//nolint:revive,staticcheck // backward compatibility
-	Id        string `json:"id"        example:"QslD_GefqiYV6RQXdkM6V"`                              // Device ID
-	PushToken string `json:"pushToken" example:"gHz-T6NezDlOfllr7F-Be" validate:"omitempty,max=256"` // FCM token of the device (optional)
+	Id        string    `json:"id"                 example:"QslD_GefqiYV6RQXdkM6V"`                              // Device ID
+	PushToken string    `json:"pushToken"          example:"gHz-T6NezDlOfllr7F-Be" validate:"omitempty,max=256"` // FCM token of the device (optional)
+	SimCards  []SimCard `json:"simCards,omitempty"`                                                              // SIM cards (optional)
 }
 
 // MobileChangePasswordRequest represents a request to change the password of a mobile device.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended device profiles to support SIM card management, allowing multiple SIMs per device with slot, phone number and carrier details.
  * Mobile registration and update endpoints now accept SIM card data, enabling clients to submit and modify a device's SIM information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/android-sms-gateway/client-go/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->