### PR TITLE
[client] separate messages export request from the inbox refresh

### DIFF
--- a/smsgateway/requests_inbox.go
+++ b/smsgateway/requests_inbox.go
@@ -4,7 +4,7 @@ import "time"
 
 // InboxRefreshRequest represents a request to export messages.
 type InboxRefreshRequest struct {
-	DeviceID        string                `json:"deviceId"                  validate:"required,max=21"                    example:"PyDmBQZZXYmyxMwED8Fzy"`                    // ID of the device to refresh messages for.
+	DeviceID        *string               `json:"deviceId,omitempty"        validate:"omitempty,max=21"                   example:"PyDmBQZZXYmyxMwED8Fzy"`                    // ID of the device to refresh messages for.
 	Since           time.Time             `json:"since"                     validate:"required,ltefield=Until"            example:"2024-01-01T00:00:00Z"  format:"date-time"` // Start of the time range to refresh.
 	Until           time.Time             `json:"until"                     validate:"required,gtefield=Since"            example:"2024-01-01T23:59:59Z"  format:"date-time"` // End of the time range to refresh.
 	MessageTypes    []IncomingMessageType `json:"messageTypes,omitempty"    validate:"omitempty,min=1,dive,oneof=SMS MMS"`                                                    // List of message types to refresh. By default, SMS messages are refreshed.
@@ -14,4 +14,8 @@ type InboxRefreshRequest struct {
 // MessagesExportRequest represents a request to export messages.
 //
 // Deprecated: use InboxRefreshRequest instead.
-type MessagesExportRequest = InboxRefreshRequest
+type MessagesExportRequest struct {
+	DeviceID string    `json:"deviceId" validate:"required,max=21"         example:"PyDmBQZZXYmyxMwED8Fzy"`                    // ID of the device to refresh messages for.
+	Since    time.Time `json:"since"    validate:"required,ltefield=Until" example:"2024-01-01T00:00:00Z"  format:"date-time"` // Start of the time range to refresh.
+	Until    time.Time `json:"until"    validate:"required,gtefield=Since" example:"2024-01-01T23:59:59Z"  format:"date-time"` // End of the time range to refresh.
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Device ID is now optional for inbox refresh requests, so requests can omit that field when not applicable.
  * Message export requests use a simplified, explicit structure (deprecated legacy shape removed), narrowing the accepted parameters and no longer including automatic webhook triggering. This clarifies API behavior and reduces unexpected side effects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/android-sms-gateway/client-go/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->