### PR TITLE
[client] add `ListInboxMessages`, `RefreshInbox` and `ListMessages`

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -27,18 +27,38 @@ func NewClient(config Config) *Client {
 }
 
 func (c *Client) Do(ctx context.Context, method, path string, headers map[string]string, payload, response any) error {
+	_, err := c.do(ctx, method, path, headers, payload, response)
+	return err
+}
+
+// DoWithResponseHeaders is like Do but also returns the response headers.
+func (c *Client) DoWithResponseHeaders(
+	ctx context.Context,
+	method, path string,
+	headers map[string]string,
+	payload, response any,
+) (http.Header, error) {
+	return c.do(ctx, method, path, headers, payload, response)
+}
+
+func (c *Client) do(
+	ctx context.Context,
+	method, path string,
+	headers map[string]string,
+	payload, response any,
+) (http.Header, error) {
 	var reqBody io.Reader
 	if payload != nil {
 		jsonBytes, err := json.Marshal(payload)
 		if err != nil {
-			return fmt.Errorf("failed to marshal payload: %w", err)
+			return nil, fmt.Errorf("failed to marshal payload: %w", err)
 		}
 		reqBody = strings.NewReader(string(jsonBytes))
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, c.config.BaseURL+path, reqBody)
 	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
+		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	if reqBody != nil {
@@ -50,7 +70,7 @@ func (c *Client) Do(ctx context.Context, method, path string, headers map[string
 
 	resp, err := c.config.Client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to make request: %w", err)
+		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)
@@ -60,18 +80,20 @@ func (c *Client) Do(ctx context.Context, method, path string, headers map[string
 	if resp.StatusCode >= http.StatusBadRequest {
 		body, _ := io.ReadAll(resp.Body)
 
-		return c.formatError(resp.StatusCode, body)
+		return resp.Header, c.formatError(resp.StatusCode, body)
 	}
 
 	if resp.StatusCode == http.StatusNoContent {
-		return nil
+		return resp.Header, nil
 	}
 
-	if decErr := json.NewDecoder(resp.Body).Decode(&response); decErr != nil {
-		return fmt.Errorf("failed to decode response: %w", decErr)
+	if response != nil {
+		if decErr := json.NewDecoder(resp.Body).Decode(response); decErr != nil {
+			return nil, fmt.Errorf("failed to decode response: %w", decErr)
+		}
 	}
 
-	return nil
+	return resp.Header, nil
 }
 
 func (c *Client) formatError(statusCode int, body []byte) error {

--- a/rest/client_test.go
+++ b/rest/client_test.go
@@ -198,9 +198,10 @@ func TestClient_Do(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:    context.Background(),
-				method: http.MethodGet,
-				path:   "/corrupt",
+				ctx:      context.Background(),
+				method:   http.MethodGet,
+				path:     "/corrupt",
+				response: &struct{}{},
 			},
 			wantErr:     true,
 			wantErrType: nil, // No specific error type expected

--- a/smsgateway/client.go
+++ b/smsgateway/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/android-sms-gateway/client-go/rest"
@@ -108,6 +109,8 @@ func (c *Client) CheckHealth(ctx context.Context) (HealthResponse, error) {
 }
 
 // ExportInbox exports messages via webhooks.
+//
+// Deprecated: use RefreshInbox instead.
 func (c *Client) ExportInbox(ctx context.Context, req MessagesExportRequest) error {
 	path := "/inbox/export"
 
@@ -116,6 +119,61 @@ func (c *Client) ExportInbox(ctx context.Context, req MessagesExportRequest) err
 	}
 
 	return nil
+}
+
+// ListInboxMessages retrieves incoming messages with filtering and pagination.
+// Returns the messages, total count (from X-Total-Count header), and error.
+func (c *Client) ListInboxMessages(ctx context.Context, opts ListInboxOptions) ([]IncomingMessage, int, error) {
+	path := "/inbox?" + opts.ToURLValues().Encode()
+	var msgs []IncomingMessage
+
+	hdr, err := c.DoWithResponseHeaders(ctx, http.MethodGet, path, c.headers, nil, &msgs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list inbox messages: %w", err)
+	}
+
+	total := 0
+	if v := hdr.Get("X-Total-Count"); v != "" {
+		total, err = strconv.Atoi(v)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to parse X-Total-Count header: %w", err)
+		}
+	}
+
+	return msgs, total, nil
+}
+
+// RefreshInbox requests an inbox messages refresh.
+func (c *Client) RefreshInbox(ctx context.Context, req InboxRefreshRequest) error {
+	path := "/inbox/refresh"
+
+	if err := c.Do(ctx, http.MethodPost, path, c.headers, &req, nil); err != nil {
+		return fmt.Errorf("failed to refresh inbox: %w", err)
+	}
+
+	return nil
+}
+
+// ListMessages retrieves messages with filtering and pagination.
+// Returns the messages, total count (from X-Total-Count header), and error.
+func (c *Client) ListMessages(ctx context.Context, opts ListMessagesOptions) ([]MessageState, int, error) {
+	path := "/messages?" + opts.ToURLValues().Encode()
+	var msgs []MessageState
+
+	hdr, err := c.DoWithResponseHeaders(ctx, http.MethodGet, path, c.headers, nil, &msgs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to list messages: %w", err)
+	}
+
+	total := 0
+	if v := hdr.Get("X-Total-Count"); v != "" {
+		total, err = strconv.Atoi(v)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to parse X-Total-Count header: %w", err)
+		}
+	}
+
+	return msgs, total, nil
 }
 
 // GetLogs retrieves log entries.
@@ -223,7 +281,7 @@ func (c *Client) GenerateToken(ctx context.Context, req TokenRequest) (TokenResp
 // RefreshToken exchanges a refresh token for a new token pair.
 // Returns the refreshed token details or an error if the request fails.
 func (c *Client) RefreshToken(ctx context.Context, refreshToken string) (TokenResponse, error) {
-	path := "/auth/refresh"
+	path := "/auth/token/refresh"
 	resp := new(TokenResponse)
 	headers := map[string]string{
 		"Authorization": "Bearer " + refreshToken,

--- a/smsgateway/client_test.go
+++ b/smsgateway/client_test.go
@@ -29,8 +29,9 @@ type mockServerExpectedInput struct {
 }
 
 type mockServerOutput struct {
-	code int
-	body string
+	code    int
+	body    string
+	headers map[string]string
 }
 
 func newMockServer(input mockServerExpectedInput, output mockServerOutput) *httptest.Server {
@@ -72,6 +73,9 @@ func newMockServer(input mockServerExpectedInput, output mockServerOutput) *http
 			return
 		}
 
+		for k, v := range output.headers {
+			w.Header().Set(k, v)
+		}
 		w.WriteHeader(output.code)
 		_, _ = w.Write([]byte(output.body))
 	}))
@@ -985,7 +989,7 @@ func TestClient_RefreshToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := newMockServer(mockServerExpectedInput{
 				method:        http.MethodPost,
-				path:          "/auth/refresh",
+				path:          "/auth/token/refresh",
 				authorization: "Bearer " + tt.refreshToken,
 			}, mockServerOutput{
 				code: tt.code,
@@ -1043,4 +1047,582 @@ func TestClient_RevokeToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_ListInboxMessages(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[{"id":"1","type":"SMS","sender":"+1234567890","contentPreview":"Hello","createdAt":"2025-01-01T00:00:00Z"}]`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		msgs, total, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(msgs) != 1 {
+			t.Errorf("Expected 1 message, got %d", len(msgs))
+		}
+		if total != 0 {
+			t.Errorf("Expected total 0, got %d", total)
+		}
+	})
+
+	t.Run("Success with X-Total-Count", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[{"id":"1","type":"SMS","sender":"+1234567890","contentPreview":"Hello","createdAt":"2025-01-01T00:00:00Z"}]`,
+			headers: map[string]string{
+				"X-Total-Count": "42",
+			},
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		msgs, total, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(msgs) != 1 {
+			t.Errorf("Expected 1 message, got %d", len(msgs))
+		}
+		if total != 42 {
+			t.Errorf("Expected total 42, got %d", total)
+		}
+	})
+
+	t.Run("Success with filters", func(t *testing.T) {
+		msgType := smsgateway.IncomingMessageTypeSMS
+		limit := 10
+		offset := 5
+		from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		to := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+		deviceID := "device123"
+
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+			query:  "deviceId=device123&from=2025-01-01T00%3A00%3A00Z&limit=10&offset=5&to=2025-01-02T00%3A00%3A00Z&type=SMS",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[]`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		msgs, total, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{
+			Type:     &msgType,
+			Limit:    &limit,
+			Offset:   &offset,
+			From:     &from,
+			To:       &to,
+			DeviceID: &deviceID,
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("Expected 0 messages, got %d", len(msgs))
+		}
+		if total != 0 {
+			t.Errorf("Expected total 0, got %d", total)
+		}
+	})
+
+	t.Run("Error response", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusInternalServerError,
+			body: `{"error": "internal error"}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Error response with body", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusBadRequest,
+			body: `{"message":"invalid request","code":400}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+}
+
+func TestClient_RefreshInbox(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method:      http.MethodPost,
+			path:        "/inbox/refresh",
+			contentType: "application/json",
+			body:        `{"since":"2025-01-01T00:00:00Z","until":"2025-01-02T00:00:00Z","triggerWebhooks":true}`,
+		}, mockServerOutput{
+			code: http.StatusAccepted,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		err := client.RefreshInbox(context.Background(), smsgateway.InboxRefreshRequest{
+			Since:           time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			Until:           time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			TriggerWebhooks: true,
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("Error response", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method:      http.MethodPost,
+			path:        "/inbox/refresh",
+			contentType: "application/json",
+			body:        `{"since":"2025-01-01T00:00:00Z","until":"2025-01-02T00:00:00Z","triggerWebhooks":true}`,
+		}, mockServerOutput{
+			code: http.StatusInternalServerError,
+			body: `{"error": "internal error"}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		err := client.RefreshInbox(context.Background(), smsgateway.InboxRefreshRequest{
+			Since:           time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			Until:           time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			TriggerWebhooks: true,
+		})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+}
+
+func TestClient_ListMessages(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[{"id":"1","deviceId":"dev123","state":"Pending","recipients":[{"phoneNumber":"+1234567890","state":"Pending"}]}]`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		msgs, total, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(msgs) != 1 {
+			t.Errorf("Expected 1 message, got %d", len(msgs))
+		}
+		if total != 0 {
+			t.Errorf("Expected total 0, got %d", total)
+		}
+	})
+
+	t.Run("Success with X-Total-Count", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[{"id":"1","deviceId":"dev123","state":"Pending","recipients":[{"phoneNumber":"+1234567890","state":"Pending"}]}]`,
+			headers: map[string]string{
+				"X-Total-Count": "99",
+			},
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		msgs, total, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(msgs) != 1 {
+			t.Errorf("Expected 1 message, got %d", len(msgs))
+		}
+		if total != 99 {
+			t.Errorf("Expected total 99, got %d", total)
+		}
+	})
+
+	t.Run("Success with filters", func(t *testing.T) {
+		from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		to := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+		state := "Pending"
+		deviceID := "dev123"
+		limit := 10
+		offset := 5
+		includeContent := true
+
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+			query:  "deviceId=dev123&from=2025-01-01T00%3A00%3A00Z&includeContent=true&limit=10&offset=5&state=Pending&to=2025-01-02T00%3A00%3A00Z",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[]`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		msgs, total, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{
+			From:           &from,
+			To:             &to,
+			State:          &state,
+			DeviceID:       &deviceID,
+			Limit:          &limit,
+			Offset:         &offset,
+			IncludeContent: &includeContent,
+		})
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("Expected 0 messages, got %d", len(msgs))
+		}
+		if total != 0 {
+			t.Errorf("Expected total 0, got %d", total)
+		}
+	})
+
+	t.Run("Error response", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusInternalServerError,
+			body: `{"error": "internal error"}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Error response with body", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusBadRequest,
+			body: `{"message":"invalid request","code":400}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusUnauthorized,
+			body: `{"message":"unauthorized","code":401}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Forbidden", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusForbidden,
+			body: `{"message":"forbidden","code":403}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Not Implemented", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusNotImplemented,
+			body: `{"message":"not implemented","code":501}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Corrupt JSON body", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `{corrupt json`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Non-numeric X-Total-Count", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[]`,
+			headers: map[string]string{
+				"X-Total-Count": "abc",
+			},
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err == nil {
+			t.Error("Expected error for non-numeric X-Total-Count, got nil")
+		}
+	})
+
+	t.Run("Network error", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/messages",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[]`,
+		})
+		server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListMessages(context.Background(), smsgateway.ListMessagesOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+}
+
+func TestClient_ListInboxMessages_Negative(t *testing.T) {
+	t.Run("Unauthorized", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusUnauthorized,
+			body: `{"message":"unauthorized","code":401}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Forbidden", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusForbidden,
+			body: `{"message":"forbidden","code":403}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Not Implemented", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusNotImplemented,
+			body: `{"message":"not implemented","code":501}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Corrupt JSON body", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `{corrupt json`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Non-numeric X-Total-Count", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[]`,
+			headers: map[string]string{
+				"X-Total-Count": "abc",
+			},
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err == nil {
+			t.Error("Expected error for non-numeric X-Total-Count, got nil")
+		}
+	})
+
+	t.Run("Network error", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method: http.MethodGet,
+			path:   "/inbox",
+		}, mockServerOutput{
+			code: http.StatusOK,
+			body: `[]`,
+		})
+		server.Close()
+
+		client := newClient(server.URL)
+		_, _, err := client.ListInboxMessages(context.Background(), smsgateway.ListInboxOptions{})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+}
+
+func TestClient_RefreshInbox_Negative(t *testing.T) {
+	t.Run("Bad Request", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method:      http.MethodPost,
+			path:        "/inbox/refresh",
+			contentType: "application/json",
+			body:        `{"since":"2025-01-01T00:00:00Z","until":"2025-01-02T00:00:00Z","triggerWebhooks":true}`,
+		}, mockServerOutput{
+			code: http.StatusBadRequest,
+			body: `{"message":"invalid request","code":400}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		err := client.RefreshInbox(context.Background(), smsgateway.InboxRefreshRequest{
+			Since:           time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			Until:           time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			TriggerWebhooks: true,
+		})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method:      http.MethodPost,
+			path:        "/inbox/refresh",
+			contentType: "application/json",
+			body:        `{"since":"2025-01-01T00:00:00Z","until":"2025-01-02T00:00:00Z","triggerWebhooks":true}`,
+		}, mockServerOutput{
+			code: http.StatusUnauthorized,
+			body: `{"message":"unauthorized","code":401}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		err := client.RefreshInbox(context.Background(), smsgateway.InboxRefreshRequest{
+			Since:           time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			Until:           time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			TriggerWebhooks: true,
+		})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("Forbidden", func(t *testing.T) {
+		server := newMockServer(mockServerExpectedInput{
+			method:      http.MethodPost,
+			path:        "/inbox/refresh",
+			contentType: "application/json",
+			body:        `{"since":"2025-01-01T00:00:00Z","until":"2025-01-02T00:00:00Z","triggerWebhooks":true}`,
+		}, mockServerOutput{
+			code: http.StatusForbidden,
+			body: `{"message":"forbidden","code":403}`,
+		})
+		defer server.Close()
+
+		client := newClient(server.URL)
+		err := client.RefreshInbox(context.Background(), smsgateway.InboxRefreshRequest{
+			Since:           time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			Until:           time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			TriggerWebhooks: true,
+		})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
 }

--- a/smsgateway/requests_3rdparty.go
+++ b/smsgateway/requests_3rdparty.go
@@ -3,6 +3,7 @@ package smsgateway
 import (
 	"net/url"
 	"strconv"
+	"time"
 )
 
 type SendOption func(*SendOptions)
@@ -47,4 +48,76 @@ func WithDeviceActiveWithin(hours uint) SendOption {
 	return func(o *SendOptions) {
 		o.deviceActiveWithin = &hours
 	}
+}
+
+// ListInboxOptions holds optional filters for listing inbox messages.
+type ListInboxOptions struct {
+	Type     *IncomingMessageType
+	Limit    *int
+	Offset   *int
+	From     *time.Time
+	To       *time.Time
+	DeviceID *string
+}
+
+// ToURLValues returns the ListInboxOptions as URL query parameters.
+func (o ListInboxOptions) ToURLValues() url.Values {
+	values := url.Values{}
+	if o.Type != nil {
+		values.Set("type", string(*o.Type))
+	}
+	if o.Limit != nil {
+		values.Set("limit", strconv.Itoa(*o.Limit))
+	}
+	if o.Offset != nil {
+		values.Set("offset", strconv.Itoa(*o.Offset))
+	}
+	if o.From != nil {
+		values.Set("from", o.From.Format(time.RFC3339))
+	}
+	if o.To != nil {
+		values.Set("to", o.To.Format(time.RFC3339))
+	}
+	if o.DeviceID != nil {
+		values.Set("deviceId", *o.DeviceID)
+	}
+	return values
+}
+
+// ListMessagesOptions holds optional filters for listing messages.
+type ListMessagesOptions struct {
+	From           *time.Time
+	To             *time.Time
+	State          *string
+	DeviceID       *string
+	Limit          *int
+	Offset         *int
+	IncludeContent *bool
+}
+
+// ToURLValues returns the ListMessagesOptions as URL query parameters.
+func (o ListMessagesOptions) ToURLValues() url.Values {
+	values := url.Values{}
+	if o.From != nil {
+		values.Set("from", o.From.Format(time.RFC3339))
+	}
+	if o.To != nil {
+		values.Set("to", o.To.Format(time.RFC3339))
+	}
+	if o.State != nil {
+		values.Set("state", *o.State)
+	}
+	if o.DeviceID != nil {
+		values.Set("deviceId", *o.DeviceID)
+	}
+	if o.Limit != nil {
+		values.Set("limit", strconv.Itoa(*o.Limit))
+	}
+	if o.Offset != nil {
+		values.Set("offset", strconv.Itoa(*o.Offset))
+	}
+	if o.IncludeContent != nil {
+		values.Set("includeContent", strconv.FormatBool(*o.IncludeContent))
+	}
+	return values
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Methods to list inbox and account messages with filtering/pagination; inbox refresh endpoint.

* **Deprecations**
  * Inbox export deprecated in favor of inbox refresh.

* **Improvements**
  * Response headers consistently returned and accessible; JSON responses decoded only when requested.

* **Chores**
  * Authentication token refresh endpoint path updated.

* **Tests**
  * Expanded test coverage for listing, refresh, header handling, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/android-sms-gateway/client-go/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->