### PR TITLE
[client] add `app:started` webhook event

### DIFF
--- a/smsgateway/domain_webhooks.go
+++ b/smsgateway/domain_webhooks.go
@@ -16,6 +16,7 @@ const (
 	WebhookEventSystemPing      WebhookEvent = "system:ping"       // Triggered when the device pings the server.
 	WebhookEventMmsReceived     WebhookEvent = "mms:received"      // Triggered when an MMS is received.
 	WebhookEventMmsDownloaded   WebhookEvent = "mms:downloaded"    // Triggered when an MMS is downloaded.
+	WebhookEventAppStarted      WebhookEvent = "app:started"       // Triggered when the application is started.
 )
 
 //nolint:gochecknoglobals // single source of truth for all webhook event types
@@ -28,6 +29,7 @@ var webhookEventTypes = []WebhookEvent{
 	WebhookEventSystemPing,
 	WebhookEventMmsReceived,
 	WebhookEventMmsDownloaded,
+	WebhookEventAppStarted,
 }
 
 //nolint:gochecknoglobals // lookup table derived from webhookEventTypes

--- a/smsgateway/dto_webhooks.go
+++ b/smsgateway/dto_webhooks.go
@@ -124,3 +124,10 @@ type MmsDownloadedPayload struct {
 
 // SystemPingPayload represents the payload of `system:ping` event.
 type SystemPingPayload struct{}
+
+// AppStartedPayload represents the payload of `app:started` event.
+//
+// SimCards is the list of SIM cards available in the device.
+type AppStartedPayload struct {
+	SimCards []SimCard `json:"simCards,omitempty"`
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for a new "app:started" webhook event that triggers when the application starts, including SIM card information in the webhook payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->