### PR TITLE
[client] add receiver content observation option

### DIFF
--- a/smsgateway/domain_settings.go
+++ b/smsgateway/domain_settings.go
@@ -57,6 +57,9 @@ type DeviceSettings struct {
 
 	// Gateway contains settings related to the gateway.
 	Gateway *SettingsGateway `json:"gateway,omitempty"`
+
+	// Receiver contains settings related to SMS message reception.
+	Receiver *SettingsReceiver `json:"receiver,omitempty"`
 }
 
 func (s DeviceSettings) Validate() error {
@@ -148,4 +151,11 @@ type SettingsGateway struct {
 
 	// NotificationChannel is the way device receives notifications.
 	NotificationChannel *string `json:"notification_channel,omitempty" validate:"omitempty,oneof=AUTO SSE_ONLY"`
+}
+
+// SettingsReceiver contains settings related to SMS message reception.
+type SettingsReceiver struct {
+	// ContentProviderEnabled enables monitoring the SMS content provider as a fallback for
+	// carriers that intercept the SMS_RECEIVED broadcast.
+	ContentProviderEnabled *bool `json:"content_provider_enabled,omitempty"`
 }

--- a/smsgateway/domain_settings_test.go
+++ b/smsgateway/domain_settings_test.go
@@ -20,6 +20,31 @@ func TestDeviceSettings_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "receiver enabled",
+			settings: smsgateway.DeviceSettings{
+				Receiver: &smsgateway.SettingsReceiver{
+					ContentProviderEnabled: ptr(true),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "receiver disabled",
+			settings: smsgateway.DeviceSettings{
+				Receiver: &smsgateway.SettingsReceiver{
+					ContentProviderEnabled: ptr(false),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "receiver nil",
+			settings: smsgateway.DeviceSettings{
+				Receiver: nil,
+			},
+			wantErr: false,
+		},
+		{
 			name: "valid messages",
 			settings: smsgateway.DeviceSettings{
 				Messages: &smsgateway.SettingsMessages{
@@ -91,6 +116,6 @@ func TestSettingsMessages_Validate(t *testing.T) {
 }
 
 // Helper function to create a pointer to an int.
-func ptr(i int) *int {
+func ptr[T any](i T) *T {
 	return &i
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added receiver-specific SMS gateway settings, including an optional content monitoring fallback option for carriers that may not deliver the usual SMS broadcast.
  * Validation now accepts receiver settings whether they are enabled, disabled, or omitted.
* **Tests**
  * Expanded coverage for device settings validation and improved a reusable helper for test values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->