### PR TITLE
[client] add sort param to list messages options

### DIFF
--- a/smsgateway/requests_3rdparty.go
+++ b/smsgateway/requests_3rdparty.go
@@ -85,15 +85,17 @@ func (o ListInboxOptions) ToURLValues() url.Values {
 	return values
 }
 
-// ListMessagesOptions holds optional filters for listing messages.
+// ListMessagesOptions holds optional filters and sorting for listing messages.
+// Sorting follows the JSON:API specification (sort parameter).
 type ListMessagesOptions struct {
-	From           *time.Time `query:"from"           validate:"omitempty"`
-	To             *time.Time `query:"to"             validate:"omitempty"`
-	State          *string    `query:"state"          validate:"omitempty,oneof=Pending Cancelling Cancelled Processed Sent Delivered Failed"`
-	DeviceID       *string    `query:"deviceId"       validate:"omitempty,len=21"`
-	Limit          *int       `query:"limit"          validate:"omitempty,min=1,max=100"`
-	Offset         *int       `query:"offset"         validate:"omitempty,min=0"`
-	IncludeContent *bool      `query:"includeContent"`
+	From           *time.Time         `query:"from"`
+	To             *time.Time         `query:"to"`
+	State          *string            `query:"state"          validate:"omitempty,oneof=Pending Cancelling Cancelled Processed Sent Delivered Failed"`
+	DeviceID       *string            `query:"deviceId"       validate:"omitempty,len=21"`
+	Limit          *int               `query:"limit"          validate:"omitempty,min=1,max=100"`
+	Offset         *int               `query:"offset"         validate:"omitempty,min=0"`
+	IncludeContent *bool              `query:"includeContent"`
+	Sort           *MessagesSortOrder `query:"sort"           validate:"omitempty,oneof=created_at -created_at"`
 }
 
 // Validate checks if the ListMessagesOptions are valid.
@@ -129,5 +131,15 @@ func (o ListMessagesOptions) ToURLValues() url.Values {
 	if o.IncludeContent != nil {
 		values.Set("includeContent", strconv.FormatBool(*o.IncludeContent))
 	}
+	if o.Sort != nil {
+		values.Set("sort", string(*o.Sort))
+	}
 	return values
 }
+
+type MessagesSortOrder string
+
+const (
+	CreatedAtAscending  MessagesSortOrder = "created_at"
+	CreatedAtDescending MessagesSortOrder = "-created_at"
+)

--- a/smsgateway/requests_3rdparty_test.go
+++ b/smsgateway/requests_3rdparty_test.go
@@ -377,6 +377,24 @@ func TestListMessagesOptions_ToURLValues(t *testing.T) {
 			},
 		},
 		{
+			name: "Sort created_at ascending",
+			options: smsgateway.ListMessagesOptions{
+				Sort: ptr(smsgateway.CreatedAtAscending),
+			},
+			expected: url.Values{
+				"sort": {"created_at"},
+			},
+		},
+		{
+			name: "Sort created_at descending",
+			options: smsgateway.ListMessagesOptions{
+				Sort: ptr(smsgateway.CreatedAtDescending),
+			},
+			expected: url.Values{
+				"sort": {"-created_at"},
+			},
+		},
+		{
 			name: "All fields set",
 			options: smsgateway.ListMessagesOptions{
 				From:           &from,
@@ -386,6 +404,7 @@ func TestListMessagesOptions_ToURLValues(t *testing.T) {
 				Limit:          ptr(100),
 				Offset:         ptr(0),
 				IncludeContent: ptr(true),
+				Sort:           ptr(smsgateway.CreatedAtDescending),
 			},
 			expected: url.Values{
 				"from":           {from.Format(time.RFC3339)},
@@ -395,6 +414,7 @@ func TestListMessagesOptions_ToURLValues(t *testing.T) {
 				"limit":          {"100"},
 				"offset":         {"0"},
 				"includeContent": {"true"},
+				"sort":           {"-created_at"},
 			},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sorting options for message listings by creation time, in ascending or descending order.
  - Added validation to ensure message list time ranges are ordered correctly.
  - Added support for passing sorting and filtering options in message list requests.

- **Tests**
  - Expanded coverage for inbox and message list query parameters, sorting, timestamps, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->